### PR TITLE
RHSSO-379: Quickstarts subsystem support

### DIFF
--- a/app-jee-jsp/README.md
+++ b/app-jee-jsp/README.md
@@ -1,10 +1,10 @@
 app-jee-jsp: JSP Service Invocation Application
 =================================================
 
-Level: Beginner  
-Technologies: JavaEE  
-Summary: JSP Service Invocation Application  
-Target Product: RH-SSO, JBoss EAP  
+Level: Beginner
+Technologies: JavaEE
+Summary: JSP Service Invocation Application
+Target Product: RH-SSO, JBoss EAP
 Source: <https://github.com/keycloak/rh-sso-quickstarts>
 
 
@@ -68,6 +68,12 @@ Build and Deploy the Quickstart
    For JBoss EAP 6.4: mvn install -Deap6 jboss-as:deploy
    ````
 
+If you prefer to secure WARs via Keycloak subsystem:
+
+   ````
+   For JBoss EAP 7:   mvn install -Dsubsystem wildfly:deploy
+   For JBoss EAP 6.4: mvn install -Dsubsystem -Deap6 jboss-as:deploy
+   ````
 
 Access the Quickstart
 ----------------------

--- a/app-jee-jsp/pom.xml
+++ b/app-jee-jsp/pom.xml
@@ -15,7 +15,8 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>com.redhat.rh-sso</groupId>
@@ -79,49 +80,7 @@
 
     <build>
         <finalName>app-jsp</finalName>
-
         <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-enforcer-plugin</artifactId>
-                <version>${version.enforcer.maven.plugin}</version>
-                <executions>
-                    <execution>
-                        <id>enforce-files-exist</id>
-                        <goals>
-                            <goal>enforce</goal>
-                        </goals>
-                        <configuration>
-                            <rules>
-                                <requireFilesExist>
-                                    <files>
-                                        <file>${basedir}/config/keycloak.json</file>
-                                    </files>
-                                </requireFilesExist>
-                            </rules>
-                            <fail>true</fail>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-war-plugin</artifactId>
-                <version>${version.war.maven.plugin}</version>
-                <configuration>
-                    <webResources>
-                        <resource>
-                            <directory>${basedir}/config</directory>
-                            <includes>
-                                <include>keycloak.json</include>
-                            </includes>
-                            <targetPath>WEB-INF</targetPath>
-                        </resource>
-                    </webResources>
-                </configuration>
-            </plugin>
-
             <plugin>
                 <groupId>org.wildfly.plugins</groupId>
                 <artifactId>wildfly-maven-plugin</artifactId>
@@ -199,6 +158,79 @@
                     <scope>provided</scope>
                 </dependency>
             </dependencies>
+        </profile>
+        <profile>
+            <id>json</id>
+            <activation>
+                <property>
+                    <name>!subsystem</name>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-enforcer-plugin</artifactId>
+                        <version>${version.enforcer.maven.plugin}</version>
+                        <executions>
+                            <execution>
+                                <id>enforce-files-exist</id>
+                                <goals>
+                                    <goal>enforce</goal>
+                                </goals>
+                                <configuration>
+                                    <rules>
+                                        <requireFilesExist>
+                                            <files>
+                                                <file>${basedir}/config/keycloak.json</file>
+                                            </files>
+                                        </requireFilesExist>
+                                    </rules>
+                                    <fail>true</fail>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-war-plugin</artifactId>
+                        <version>${version.war.maven.plugin}</version>
+                        <configuration>
+                            <failOnMissingWebXml>false</failOnMissingWebXml>
+
+                            <webResources>
+                                <resource>
+                                    <directory>${basedir}/config</directory>
+                                    <includes>
+                                        <include>keycloak.json</include>
+                                    </includes>
+                                </resource>
+                            </webResources>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>subsystem</id>
+            <activation>
+                <property>
+                    <name>subsystem</name>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-war-plugin</artifactId>
+                        <version>${version.war.maven.plugin}</version>
+                        <configuration>
+                            <failOnMissingWebXml>false</failOnMissingWebXml>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
         </profile>
     </profiles>
 </project>

--- a/app-profile-jee-jsp/README.md
+++ b/app-profile-jee-jsp/README.md
@@ -1,10 +1,10 @@
 app-profile-jee-jsp: JSP Profile Application
 ================================================
 
-Level: Beginner  
-Technologies: JavaEE  
-Summary: JSP Profile Application  
-Target Product: RH-SSO, JBoss EAP  
+Level: Beginner
+Technologies: JavaEE
+Summary: JSP Profile Application
+Target Product: RH-SSO, JBoss EAP
 Source: <https://github.com/keycloak/rh-sso-quickstarts>
 
 
@@ -67,6 +67,12 @@ Build and Deploy the Quickstart
    For JBoss EAP 6.4: mvn install -Deap6 jboss-as:deploy
    ````
 
+If you prefer to secure WARs via Keycloak subsystem:
+
+   ````
+   For JBoss EAP 7:   mvn install -Dsubsystem wildfly:deploy
+   For JBoss EAP 6.4: mvn install -Dsubsystem -Deap6 jboss-as:deploy
+   ````
 
 Access the Quickstart
 ----------------------

--- a/app-profile-jee-jsp/pom.xml
+++ b/app-profile-jee-jsp/pom.xml
@@ -77,47 +77,6 @@
 
         <plugins>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-enforcer-plugin</artifactId>
-                <version>${version.enforcer.maven.plugin}</version>
-                <executions>
-                    <execution>
-                        <id>enforce-files-exist</id>
-                        <goals>
-                            <goal>enforce</goal>
-                        </goals>
-                        <configuration>
-                            <rules>
-                                <requireFilesExist>
-                                    <files>
-                                        <file>${basedir}/config/keycloak.json</file>
-                                    </files>
-                                </requireFilesExist>
-                            </rules>
-                            <fail>true</fail>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-war-plugin</artifactId>
-                <version>${version.war.maven.plugin}</version>
-                <configuration>
-                    <webResources>
-                        <resource>
-                            <directory>${basedir}/config</directory>
-                            <includes>
-                                <include>keycloak.json</include>
-                            </includes>
-                            <targetPath>WEB-INF</targetPath>
-                        </resource>
-                    </webResources>
-                </configuration>
-            </plugin>
-
-            <plugin>
                 <groupId>org.wildfly.plugins</groupId>
                 <artifactId>wildfly-maven-plugin</artifactId>
                 <version>${version.wildfly.maven.plugin}</version>
@@ -194,6 +153,78 @@
                     <scope>provided</scope>
                 </dependency>
             </dependencies>
+        </profile>
+        <profile>
+            <id>json</id>
+            <activation>
+                <property>
+                    <name>!subsystem</name>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-enforcer-plugin</artifactId>
+                        <version>${version.enforcer.maven.plugin}</version>
+                        <executions>
+                            <execution>
+                                <id>enforce-files-exist</id>
+                                <goals>
+                                    <goal>enforce</goal>
+                                </goals>
+                                <configuration>
+                                    <rules>
+                                        <requireFilesExist>
+                                            <files>
+                                                <file>${basedir}/config/keycloak.json</file>
+                                            </files>
+                                        </requireFilesExist>
+                                    </rules>
+                                    <fail>true</fail>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-war-plugin</artifactId>
+                        <version>${version.war.maven.plugin}</version>
+                        <configuration>
+                            <failOnMissingWebXml>false</failOnMissingWebXml>
+                            <webResources>
+                                <resource>
+                                    <directory>${basedir}/config</directory>
+                                    <includes>
+                                        <include>keycloak.json</include>
+                                    </includes>
+                                </resource>
+                            </webResources>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>subsystem</id>
+            <activation>
+                <property>
+                    <name>subsystem</name>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-war-plugin</artifactId>
+                        <version>${version.war.maven.plugin}</version>
+                        <configuration>
+                            <failOnMissingWebXml>false</failOnMissingWebXml>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
         </profile>
     </profiles>
 </project>

--- a/app-profile-saml-jee-jsp/README.md
+++ b/app-profile-saml-jee-jsp/README.md
@@ -1,10 +1,10 @@
 app-profile-saml-jee-jsp: HTML5 Profile Application with SAML
 =============================================================
 
-Level: Beginner  
-Technologies: JavaEE  
-Summary: JSP Profile Application  
-Target Product: RH-SSO, JBoss EAP  
+Level: Beginner
+Technologies: JavaEE
+Summary: JSP Profile Application
+Target Product: RH-SSO, JBoss EAP
 Source: <https://github.com/keycloak/rh-sso-quickstarts>
 
 
@@ -71,11 +71,17 @@ Build and Deploy the Quickstart
 
 2. The following shows the command to deploy the quickstart:
 
-````
-For JBoss EAP 7:   mvn install wildfly:deploy
-For JBoss EAP 6.4: mvn install -Deap6 jboss-as:deploy
-````
+   ````
+   For JBoss EAP 7:   mvn install wildfly:deploy
+   For JBoss EAP 6.4: mvn install -Deap6 jboss-as:deploy
+   ````
 
+If you prefer to secure WARs via Keycloak SAML subsystem:
+
+   ````
+   For JBoss EAP 7:   mvn install -Dsubsystem wildfly:deploy
+   For JBoss EAP 6.4: mvn install -Dsubsystem -Deap6 jboss-as:deploy
+   ````
 
 Access the Quickstart
 ----------------------

--- a/app-profile-saml-jee-jsp/pom.xml
+++ b/app-profile-saml-jee-jsp/pom.xml
@@ -15,7 +15,8 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>com.redhat.rh-sso</groupId>
@@ -85,47 +86,6 @@
     <build>
         <finalName>app-profile-saml</finalName>
         <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-enforcer-plugin</artifactId>
-                <version>${version.enforcer.maven.plugin}</version>
-                <executions>
-                    <execution>
-                        <id>enforce-files-exist</id>
-                        <goals>
-                            <goal>enforce</goal>
-                        </goals>
-                        <configuration>
-                            <rules>
-                                <requireFilesExist>
-                                    <files>
-                                        <file>${basedir}/config/keycloak-saml.xml</file>
-                                    </files>
-                                </requireFilesExist>
-                            </rules>
-                            <fail>true</fail>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-war-plugin</artifactId>
-                <version>${version.war.maven.plugin}</version>
-                <configuration>
-                    <webResources>
-                        <resource>
-                            <directory>${basedir}/config</directory>
-                            <includes>
-                                <include>keycloak-saml.xml</include>
-                            </includes>
-                            <targetPath>WEB-INF</targetPath>
-                        </resource>
-                    </webResources>
-                </configuration>
-            </plugin>
-
             <plugin>
                 <groupId>org.wildfly.plugins</groupId>
                 <artifactId>wildfly-maven-plugin</artifactId>
@@ -203,6 +163,78 @@
                     <scope>provided</scope>
                 </dependency>
             </dependencies>
+        </profile>
+
+        <profile>
+            <id>xml</id>
+            <activation>
+                <property>
+                    <name>!subsystem</name>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-enforcer-plugin</artifactId>
+                        <version>${version.enforcer.maven.plugin}</version>
+                        <executions>
+                            <execution>
+                                <id>enforce-files-exist</id>
+                                <goals>
+                                    <goal>enforce</goal>
+                                </goals>
+                                <configuration>
+                                    <rules>
+                                        <requireFilesExist>
+                                            <files>
+                                                <file>${basedir}/config/keycloak-saml.xml</file>
+                                            </files>
+                                        </requireFilesExist>
+                                    </rules>
+                                    <fail>true</fail>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-war-plugin</artifactId>
+                        <version>${version.war.maven.plugin}</version>
+                        <configuration>
+                            <webResources>
+                                <resource>
+                                    <directory>${basedir}/config</directory>
+                                    <includes>
+                                        <include>keycloak-saml.xml</include>
+                                    </includes>
+                                    <targetPath>WEB-INF</targetPath>
+                                </resource>
+                            </webResources>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>subsystem</id>
+            <activation>
+                <property>
+                    <name>subsystem</name>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-war-plugin</artifactId>
+                        <version>${version.war.maven.plugin}</version>
+                        <configuration>
+                            <failOnMissingWebXml>false</failOnMissingWebXml>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
         </profile>
     </profiles>
 </project>

--- a/service-jee-jaxrs/README.md
+++ b/service-jee-jaxrs/README.md
@@ -1,10 +1,10 @@
 service-jee-jaxrs: JAX-RS Service
 ===================================================
 
-Level: Beginner  
-Technologies: JavaEE  
-Summary: JAX-RS Service  
-Target Product: RH-SSO, JBoss EAP  
+Level: Beginner
+Technologies: JavaEE
+Summary: JAX-RS Service
+Target Product: RH-SSO, JBoss EAP
 Source: <https://github.com/keycloak/rh-sso-quickstarts>
 
 
@@ -77,6 +77,12 @@ Build and Deploy the Quickstart
    For JBoss EAP 6.4: mvn install -Deap6 jboss-as:deploy
    ````
 
+If you prefer to secure WARs via Keycloak subsystem:
+
+   ````
+   For JBoss EAP 7:   mvn install -Dsubsystem wildfly:deploy
+   For JBoss EAP 6.4: mvn install -Dsubsystem -Deap6 jboss-as:deploy
+   ````
 
 Access the Quickstart
 ---------------------

--- a/service-jee-jaxrs/pom.xml
+++ b/service-jee-jaxrs/pom.xml
@@ -58,47 +58,6 @@
         <finalName>service</finalName>
         <plugins>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-enforcer-plugin</artifactId>
-                <version>${version.enforcer.maven.plugin}</version>
-                <executions>
-                    <execution>
-                        <id>enforce-files-exist</id>
-                        <goals>
-                            <goal>enforce</goal>
-                        </goals>
-                        <configuration>
-                            <rules>
-                                <requireFilesExist>
-                                    <files>
-                                        <file>${basedir}/config/keycloak.json</file>
-                                    </files>
-                                </requireFilesExist>
-                            </rules>
-                            <fail>true</fail>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-war-plugin</artifactId>
-                <version>${version.war.maven.plugin}</version>
-                <configuration>
-                    <webResources>
-                        <resource>
-                            <directory>${basedir}/config</directory>
-                            <includes>
-                                <include>keycloak.json</include>
-                            </includes>
-                            <targetPath>WEB-INF</targetPath>
-                        </resource>
-                    </webResources>
-                </configuration>
-            </plugin>
-
-            <plugin>
                 <groupId>org.wildfly.plugins</groupId>
                 <artifactId>wildfly-maven-plugin</artifactId>
                 <version>${version.wildfly.maven.plugin}</version>
@@ -185,6 +144,79 @@
                     <artifactId>jboss-jaxrs-api_1.1_spec</artifactId>
                 </dependency>
             </dependencies>
+        </profile>
+        <profile>
+            <id>json</id>
+            <activation>
+                <property>
+                    <name>!subsystem</name>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-enforcer-plugin</artifactId>
+                        <version>${version.enforcer.maven.plugin}</version>
+                        <executions>
+                            <execution>
+                                <id>enforce-files-exist</id>
+                                <goals>
+                                    <goal>enforce</goal>
+                                </goals>
+                                <configuration>
+                                    <rules>
+                                        <requireFilesExist>
+                                            <files>
+                                                <file>${basedir}/config/keycloak.json</file>
+                                            </files>
+                                        </requireFilesExist>
+                                    </rules>
+                                    <fail>true</fail>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-war-plugin</artifactId>
+                        <version>${version.war.maven.plugin}</version>
+                        <configuration>
+                            <failOnMissingWebXml>false</failOnMissingWebXml>
+
+                            <webResources>
+                                <resource>
+                                    <directory>${basedir}/config</directory>
+                                    <includes>
+                                        <include>keycloak.json</include>
+                                    </includes>
+                                </resource>
+                            </webResources>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>subsystem</id>
+            <activation>
+                <property>
+                    <name>subsystem</name>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-war-plugin</artifactId>
+                        <version>${version.war.maven.plugin}</version>
+                        <configuration>
+                            <failOnMissingWebXml>false</failOnMissingWebXml>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
         </profile>
     </profiles>
 </project>


### PR DESCRIPTION
@stianst I just decided to stick with your original suggestion, because eap7 is already active by default in all the examples.

One thing that would be interesting, is to have a POM parent and make POM files inside the examples to extend it. I noticed that some profiles are the same thing. Nothing critical, but could avoid some copy & paste.

Let me know what do you think and I can file a Jira.
