### PR TITLE
WEB-INF is required at target path, otherwise default profile won't work

### DIFF
--- a/app-jee-jsp/pom.xml
+++ b/app-jee-jsp/pom.xml
@@ -205,6 +205,7 @@
                                     <includes>
                                         <include>keycloak.json</include>
                                     </includes>
+                                    <targetPath>WEB-INF</targetPath>
                                 </resource>
                             </webResources>
                         </configuration>

--- a/app-profile-jee-jsp/pom.xml
+++ b/app-profile-jee-jsp/pom.xml
@@ -199,6 +199,7 @@
                                     <includes>
                                         <include>keycloak.json</include>
                                     </includes>
+                                    <targetPath>WEB-INF</targetPath>
                                 </resource>
                             </webResources>
                         </configuration>

--- a/service-jee-jaxrs/pom.xml
+++ b/service-jee-jaxrs/pom.xml
@@ -191,6 +191,7 @@
                                     <includes>
                                         <include>keycloak.json</include>
                                     </includes>
+                                    <targetPath>WEB-INF</targetPath>
                                 </resource>
                             </webResources>
                         </configuration>


### PR DESCRIPTION
@stianst targetPath must be added, otherwise keycloak.json won't be added to WEB-INF folder. Instead, the plugin puts it into the root folder.
