### PR TITLE
RHSSO-381 Incorrect page after failed login due to missing role

### DIFF
--- a/app-jee-jsp/pom.xml
+++ b/app-jee-jsp/pom.xml
@@ -205,6 +205,7 @@
                                     <includes>
                                         <include>keycloak.json</include>
                                     </includes>
+                                    <targetPath>WEB-INF</targetPath>
                                 </resource>
                             </webResources>
                         </configuration>

--- a/app-jee-jsp/src/main/webapp/WEB-INF/web.xml
+++ b/app-jee-jsp/src/main/webapp/WEB-INF/web.xml
@@ -25,7 +25,7 @@
             <url-pattern>/protected.jsp</url-pattern>
         </web-resource-collection>
         <auth-constraint>
-            <role-name>user</role-name>
+            <role-name>*</role-name>
         </auth-constraint>
     </security-constraint>
 
@@ -34,6 +34,6 @@
     </login-config>
 
     <security-role>
-        <role-name>user</role-name>
+        <role-name>*</role-name>
     </security-role>
 </web-app>

--- a/app-profile-jee-jsp/pom.xml
+++ b/app-profile-jee-jsp/pom.xml
@@ -199,6 +199,7 @@
                                     <includes>
                                         <include>keycloak.json</include>
                                     </includes>
+                                    <targetPath>WEB-INF</targetPath>
                                 </resource>
                             </webResources>
                         </configuration>

--- a/app-profile-jee-jsp/src/main/webapp/WEB-INF/web.xml
+++ b/app-profile-jee-jsp/src/main/webapp/WEB-INF/web.xml
@@ -25,7 +25,7 @@
             <url-pattern>/profile.jsp</url-pattern>
         </web-resource-collection>
         <auth-constraint>
-            <role-name>user</role-name>
+            <role-name>*</role-name>
         </auth-constraint>
     </security-constraint>
 
@@ -34,6 +34,6 @@
     </login-config>
 
     <security-role>
-        <role-name>user</role-name>
+        <role-name>*</role-name>
     </security-role>
 </web-app>

--- a/service-jee-jaxrs/pom.xml
+++ b/service-jee-jaxrs/pom.xml
@@ -191,6 +191,7 @@
                                     <includes>
                                         <include>keycloak.json</include>
                                     </includes>
+                                    <targetPath>WEB-INF</targetPath>
                                 </resource>
                             </webResources>
                         </configuration>


### PR DESCRIPTION
targetPath must be added, otherwise keycloak.json won't be added to WEB-INF folder. Instead, the plugin puts it into the root folder.
