### PR TITLE
[KEYCLOAK-13664] Fix broken links in Fuse63 READMEs

### DIFF
--- a/fuse63/app-war/README.md
+++ b/fuse63/app-war/README.md
@@ -58,7 +58,7 @@ copying [config/keycloak-example.json](config/keycloak-example.json) to `config/
 Build the Quickstart
 --------------------
 
-1. Open a terminal and navigate to the [fuse63](../fuse63) directory.
+1. Open a terminal and navigate to the [fuse63](../) directory.
 
 ```
 mvn clean install

--- a/fuse63/service-camel/README.md
+++ b/fuse63/service-camel/README.md
@@ -70,7 +70,7 @@ copying [config/keycloak-example.json](config/keycloak-example.json) to `src/mai
 Build the Quickstart
 --------------------
 
-1. Open a terminal and navigate to the [fuse63](../fuse63) directory.
+1. Open a terminal and navigate to the [fuse63](../) directory.
 
 ```
 mvn clean install

--- a/fuse63/service-cxf-jaxrs/README.md
+++ b/fuse63/service-cxf-jaxrs/README.md
@@ -71,7 +71,7 @@ copying [config/keycloak-example.json](config/keycloak-example.json) to `src/mai
 Build the Quickstart
 --------------------
 
-1. Open a terminal and navigate to the [fuse63](../fuse63) directory.
+1. Open a terminal and navigate to the [fuse63](../) directory.
 
 ```
 mvn clean install


### PR DESCRIPTION
(cherry picked from commit 9149e8f356aa2cb151d0d09cc956408f4e098fe1)

<!---
Please read https://github.com/keycloak/keycloak/blob/master/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
