### PR TITLE
Make war maven plugin version configurable

### DIFF
--- a/app-profile-jee-vanilla/pom.xml
+++ b/app-profile-jee-vanilla/pom.xml
@@ -77,6 +77,12 @@
                     <skip>false</skip>
                 </configuration>
             </plugin>
+            
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-war-plugin</artifactId>
+                <version>${version.war.maven.plugin}</version>
+            </plugin>
         </plugins>
     </build>
 


### PR DESCRIPTION
The war maven plugin version is not configurable for app-profile-jee-vanilla. This PR simply allows to set the plugin version thanks to version.war.maven.plugin system property